### PR TITLE
Website refont

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,12 +1,27 @@
 baseURL = "https://mpcsec.org/"
 title = "Common MPC Pitfalls"
 languageCode = "en-us"
-staticDir = ["static", "skill"]
-disableKinds = ["taxonomy", "term", "RSS", "sitemap", "robotsTXT", "404"]
+disableKinds = ["taxonomy", "term", "rss", "sitemap", "robotstxt", "404"]
+
+[[module.mounts]]
+source = "content"
+target = "content"
+
+[[module.mounts]]
+source = "layouts"
+target = "layouts"
+
+[[module.mounts]]
+source = "static"
+target = "static"
+
+[[module.mounts]]
+source = "skill"
+target = "static"
 
 [outputs]
 home = ["HTML", "llms"]
-page = []
+page = ["HTML"]
 section = ["HTML"]
 
 [outputFormats.llms]
@@ -17,6 +32,7 @@ isPlainText = true
 [markup.highlight]
 lineNos = true
 lineNumbersInTable = false
+noClasses = false
 
 [markup.goldmark.parser]
 autoHeadingID = false

--- a/layouts/bugs/list.html
+++ b/layouts/bugs/list.html
@@ -19,6 +19,7 @@
         {{ if isset $bugMap .File.BaseFileName }}{{ $bugs = $bugs | append . }}{{ end }}
     {{ end }}
     {{ $bugs = sort $bugs "Date" "desc" }}
+    {{ $intros := sort (where (where .Site.RegularPages "Section" "pitfalls") "Params.intro" true) "Params.order" }}
     {{ $desc := printf "A tracker of %d real-world MPC implementation bugs mapped to common MPC pitfalls." (len $bugs) }}
     <meta name="description" content="{{ $desc }}">
 
@@ -38,11 +39,7 @@
 
     <script>
         (() => {
-            try {
-                const saved = localStorage.getItem("mpc-pitfalls-theme-mode");
-                const system = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-                document.documentElement.dataset.theme = saved === "dark" || saved === "light" ? saved : system;
-            } catch (_) {}
+            document.documentElement.dataset.theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
         })();
     </script>
     <link rel="icon" href="{{ "favicon.svg" | relURL }}" type="image/svg+xml">
@@ -58,16 +55,19 @@
             ]
         });"></script>
 </head>
-<body class="tracker-page">
-    <a class="page-back-arrow" href="{{ "/" | relURL }}" aria-label="Back to Common MPC Pitfalls" title="Back to Common MPC Pitfalls">←</a>
-    <header>
-        <button class="theme-toggle" type="button" data-theme-toggle aria-label="Switch theme"></button>
-        <p class="eyebrow"><a href="{{ "/" | relURL }}">Common MPC Pitfalls</a></p>
-        <h1>{{ .Title }}</h1>
-        <p>A searchable list of real-world MPC bugs, mapped to the pitfall taxonomy.</p>
-    </header>
+<body class="docs-home-page tracker-page">
+    {{ partial "page-controls.html" . }}
 
-    <main>
+    <div class="docs-layout">
+        {{ partial "docs-sidebar.html" (dict "current" "bugs" "intros" $intros) }}
+
+        <main class="docs-content tracker-content">
+        <header class="tracker-header">
+            <p class="eyebrow"><a href="{{ "/" | relURL }}">Common MPC Pitfalls</a></p>
+            <h1>{{ .Title }}</h1>
+            <p>A searchable list of real-world MPC bugs, mapped to the pitfall taxonomy.</p>
+        </header>
+
         <section class="tracker-summary" aria-label="Bug tracker summary">
             <div>
                 <strong>{{ len $bugs }}</strong>
@@ -145,7 +145,7 @@
                                 <p class="bug-preview">{{ .Summary | plainify }}</p>
                             </td>
                             <td>
-                                <a class="pitfall-link" href="{{ printf "/#%s" ($pf.Title | anchorize) | relURL }}" target="_blank" rel="noopener noreferrer">{{ $pf.Title }}</a>
+                                <a class="pitfall-link" href="{{ $pf.RelPermalink }}" target="_blank" rel="noopener noreferrer">{{ $pf.Title }}</a>
                             </td>
                             <td>
                                 <button class="category-tag category-link" type="button" data-category-id="{{ $pf.Params.class }}">{{ $pf.Params.class | humanize }}</button>
@@ -171,7 +171,9 @@
             </div>
         </section>
         <p class="tracker-empty" id="tracker-empty" hidden>No bugs match the current filters.</p>
-    </main>
+        <button class="tracker-page-top" type="button" data-tracker-top aria-label="Scroll to top of bug tracker" title="Back to top" onclick="window.scrollTo(0, 0); document.documentElement.scrollTop = 0; document.body.scrollTop = 0;">↑</button>
+        </main>
+    </div>
 
     <section class="pitfall-overlay bug-overlay" id="bug-overlay" aria-modal="true" role="dialog" aria-label="Bug detail" hidden>
         <div class="pitfall-overlay-backdrop" data-bug-close></div>
@@ -195,7 +197,7 @@
                         </div>
                         <div>
                             <dt>Pitfall</dt>
-                            <dd><a class="pitfall-link" href="{{ printf "/#%s" ($pf.Title | anchorize) | relURL }}" target="_blank" rel="noopener noreferrer">{{ $pf.Title }}</a></dd>
+                            <dd><a class="pitfall-link" href="{{ $pf.RelPermalink }}" target="_blank" rel="noopener noreferrer">{{ $pf.Title }}</a></dd>
                         </div>
                         {{ if gt (len $refs) 0 }}
                         <div>
@@ -218,6 +220,7 @@
                     <div class="bug-detail-body">{{ .Content }}</div>
                 </article>
             {{ end }}
+            <button class="pitfall-overlay-top" type="button" data-bug-top aria-label="Scroll to top of bug report" title="Back to top" onclick="const panel = this.closest('.pitfall-overlay-panel'); if (panel) { panel.scrollTop = 0; if (panel.scrollTo) panel.scrollTo(0, 0); }">↑</button>
         </div>
     </section>
 
@@ -232,7 +235,7 @@
                 <article class="category-overlay-content" data-category-id="{{ .Params.class }}" hidden>
                     <h2>{{ .Title }}</h2>
                     <div>{{ .Content }}</div>
-                    <p class="pitfall-overlay-main-link"><a href="{{ printf "/#category-%s" (.Params.class | anchorize) | relURL }}">Open on main page</a></p>
+                    <p class="pitfall-overlay-main-link"><a href="{{ .RelPermalink }}" target="_blank" rel="noopener noreferrer">Open category page</a></p>
                 </article>
             {{ end }}
         </div>

--- a/layouts/bugs/list.html
+++ b/layouts/bugs/list.html
@@ -37,11 +37,7 @@
     <meta name="twitter:description" content="{{ $desc }}">
     <meta name="twitter:image" content="{{ "og-image.png" | absURL }}">
 
-    <script>
-        (() => {
-            document.documentElement.dataset.theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-        })();
-    </script>
+    {{ partial "theme-head.html" . }}
     <link rel="icon" href="{{ "favicon.svg" | relURL }}" type="image/svg+xml">
     <link rel="icon" href="{{ "favicon.png" | relURL }}" type="image/png" sizes="1024x1024">
     <link rel="stylesheet" href="{{ "style.css" | relURL }}">

--- a/layouts/bugs/single.html
+++ b/layouts/bugs/single.html
@@ -5,11 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ .Title }} | Common MPC Pitfalls</title>
     <meta name="description" content="{{ .Summary | plainify }}">
-    <script>
-        (() => {
-            document.documentElement.dataset.theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-        })();
-    </script>
+    {{ partial "theme-head.html" . }}
     <link rel="icon" href="{{ "favicon.svg" | relURL }}" type="image/svg+xml">
     <link rel="icon" href="{{ "favicon.png" | relURL }}" type="image/png" sizes="1024x1024">
     <link rel="stylesheet" href="{{ "style.css" | relURL }}">

--- a/layouts/bugs/single.html
+++ b/layouts/bugs/single.html
@@ -3,9 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pitfall Categories</title>
-    {{ $desc := "The current Common MPC Pitfalls categories." }}
-    <meta name="description" content="{{ $desc }}">
+    <title>{{ .Title }} | Common MPC Pitfalls</title>
+    <meta name="description" content="{{ .Summary | plainify }}">
     <script>
         (() => {
             document.documentElement.dataset.theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
@@ -24,28 +23,18 @@
             ]
         });"></script>
 </head>
-<body class="docs-home-page">
-    {{ $allPages := where .Site.RegularPages "Section" "pitfalls" }}
-    {{ $intros := sort (where $allPages "Params.intro" true) "Params.order" }}
-    {{ $pitfalls := sort (where (where $allPages "Params.intro" "ne" true) "Params.hidden" "ne" true) "Params.order" }}
-
-    {{ partial "page-controls.html" . }}
-
-    <div class="docs-layout">
-        {{ partial "docs-sidebar.html" (dict "intros" $intros) }}
-
-        <main class="docs-content">
-            <h1>Pitfall Categories</h1>
-            <p class="lede">The current categories used to organize common mistakes in MPC implementations.</p>
-
-            <ol class="docs-category-list">
-                {{ range $intros }}
-                    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
-                {{ end }}
-            </ol>
-        </main>
-    </div>
-
+<body>
+    <a class="page-back-arrow" href="{{ "bugs/" | relURL }}" aria-label="Back to MPC Bug Tracker" title="Back to MPC Bug Tracker">←</a>
+    <header>
+        <button class="theme-toggle" type="button" data-theme-toggle aria-label="Switch theme"></button>
+        <p class="eyebrow"><a href="{{ "/" | relURL }}">Common MPC Pitfalls</a></p>
+        <h1>{{ .Title }}</h1>
+    </header>
+    <main>
+        <article class="bug-detail-body">
+            {{ .Content }}
+        </article>
+    </main>
     <script defer src="{{ "scripts/theme.js" | relURL }}"></script>
     <script defer src="{{ "scripts/external-links.js" | relURL }}"></script>
 </body>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -21,11 +21,7 @@
     <meta name="twitter:description" content="{{ $desc }}">
     <meta name="twitter:image" content="{{ "og-image.png" | absURL }}">
 
-    <script>
-        (() => {
-            document.documentElement.dataset.theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-        })();
-    </script>
+    {{ partial "theme-head.html" . }}
     <link rel="icon" href="{{ "favicon.svg" | relURL }}" type="image/svg+xml">
     <link rel="icon" href="{{ "favicon.png" | relURL }}" type="image/png" sizes="1024x1024">
     <link rel="stylesheet" href="{{ "style.css" | relURL }}">
@@ -46,11 +42,11 @@
             <section id="about-the-project">
                 <h2>About the Project</h2>
                 <p>The project is built to help developers and auditors implement MPC securely. It started at the RWMPC 2025 workshop, where practitioners from across the field agreed it needed a shared reference for the implementation mistakes that keep recurring.</p>
-                <p>The <a href="{{ "bugs/" | relURL }}" target="_blank" rel="noopener">MPC Bug Tracker</a> backs the pitfalls with a searchable list of real-world bugs mapped to them.</p>
+                <p>On this site we have collected and categorized the most common mistakes in MPC implementations. Additionally, we track <a href="{{ "bugs/" | relURL }}" target="_blank" rel="noopener">bugs across the MPC ecosystem</a> and provide an <a href="{{ "SKILL.md" | relURL }}" target="_blank" rel="noopener">MPC auditing skill</a> for use with agents, both during MPC development and for known-vulnerability detection and auditing.</p>
             </section>
 
             <section id="pitfall-categories-overview">
-                <h2>Current Pitfall Categories</h2>
+                <h2>Categories</h2>
                 <ul class="pitfall-list">
                     {{ range $intros }}
                     <li>
@@ -65,11 +61,6 @@
                 </ul>
             </section>
 
-            <section id="links">
-                <h2>Links</h2>
-                <p>Audit your MPC implementation with the <a href="{{ "SKILL.md" | relURL }}">auditing skill</a>, or <a href="https://github.com/rot256/mpc-pitfalls">discuss and contribute on GitHub</a>.</p>
-            </section>
-
             <section id="contributors">
                 <h2>Contributors</h2>
                 <ul class="contributors-list">
@@ -81,6 +72,7 @@
                     </li>
                     {{ end }}
                 </ul>
+                <p><a href="https://github.com/rot256/mpc-pitfalls">Discuss and contribute on GitHub</a>.</p>
             </section>
         </main>
     </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -23,125 +23,72 @@
 
     <script>
         (() => {
-            try {
-                const saved = localStorage.getItem("mpc-pitfalls-theme-mode");
-                const system = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-                document.documentElement.dataset.theme = saved === "dark" || saved === "light" ? saved : system;
-            } catch (_) {}
+            document.documentElement.dataset.theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
         })();
     </script>
     <link rel="icon" href="{{ "favicon.svg" | relURL }}" type="image/svg+xml">
     <link rel="icon" href="{{ "favicon.png" | relURL }}" type="image/png" sizes="1024x1024">
     <link rel="stylesheet" href="{{ "style.css" | relURL }}">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.28/dist/katex.min.css">
-    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.28/dist/katex.min.js"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.28/dist/contrib/auto-render.min.js"
-        onload="renderMathInElement(document.body, {
-            delimiters: [
-                {left: '$$', right: '$$', display: true},
-                {left: '$', right: '$', display: false}
-            ]
-        });"></script>
 </head>
-<body>
-    <header>
-        <button class="theme-toggle" type="button" data-theme-toggle aria-label="Switch theme"></button>
-        <h1>Common Multi-Party Computation Pitfalls</h1>
-        <p>A collection of common mistakes when implementing MPC protocols, to help developers implement MPC securely.</p>
-        <p class="tracker-link"><a href="{{ "bugs/" | relURL }}">Browse the MPC bug tracker</a></p>
-        <p class="skill-link">Audit your MPC implementation with an AI agent using the <a href="{{ "SKILL.md" | relURL }}">auditing skill</a>.</p>
-    </header>
-
+<body class="docs-home-page">
     {{ $allPages := where .Site.RegularPages "Section" "pitfalls" }}
     {{ $intros := sort (where $allPages "Params.intro" true) "Params.order" }}
-    {{ $pitfalls := sort (where (where $allPages "Params.intro" "ne" true) "Params.hidden" "ne" true) "Params.order" }}
 
-    <nav>
-        <h2>Table of Contents</h2>
-        <ul class="toc">
-        {{ range $intros }}
-            <li class="toc-category">
-                <a class="toc-category-link" href="#category-{{ .Params.class | anchorize }}">{{ .Title }}</a>
-                <ol>
-                {{ range (where $pitfalls "Params.class" .Params.class) }}
-                    <li><a {{ printf "href=\"#%s\"" (.Title | anchorize) | safeHTMLAttr }}>{{ .Title }}</a></li>
-                {{ end }}
-                </ol>
-            </li>
-        {{ end }}
-        </ul>
-    </nav>
+    {{ partial "page-controls.html" . }}
 
-    <main>
-    {{ range $intros }}
-        <section class="category" id="category-{{ .Params.class | anchorize }}">
-            <h2 class="category-heading">{{ .Title }}</h2>
-            <div class="category-intro">{{ .Content }}</div>
-            {{ range (where $pitfalls "Params.class" .Params.class) }}
-                <section class="pitfall" id="{{ .Title | anchorize }}">
-                    <h3>{{ .Title }}</h3>
-                    {{ .Content }}
-                    {{ range .Params.display }}
-                        {{ $bug := site.GetPage (printf "/bugs/%s" .) }}
-                        {{ with $bug }}
-                        {{ $repo := .Params.repository }}
-                        {{ $refs := slice }}
-                        {{ with .Params.source }}
-                            {{ range . }}
-                                {{ $refs = $refs | append (printf "[%s](%s)" .name .url) }}
-                            {{ end }}
-                        {{ end }}
-                        {{ with .Params.cve }}
-                            {{ $refs = $refs | append (printf "[%s](%s)" .name .url) }}
-                        {{ end }}
-                        {{ with .Params.issue }}
-                            {{ $issues := . }}
-                            {{ if not (reflect.IsSlice .) }}{{ $issues = slice . }}{{ end }}
-                            {{ range $issues }}
-                                {{ $refs = $refs | append (printf "[Issue #%d](%s/issues/%d)" . $repo .) }}
-                            {{ end }}
-                        {{ end }}
-                        {{ with .Params.pr }}
-                            {{ $prs := . }}
-                            {{ if not (reflect.IsSlice .) }}{{ $prs = slice . }}{{ end }}
-                            {{ range $prs }}
-                                {{ $refs = $refs | append (printf "[PR #%d](%s/pull/%d)" . $repo .) }}
-                            {{ end }}
-                        {{ end }}
-                        {{ with .Params.commit }}
-                            {{ $commits := . }}
-                            {{ if not (reflect.IsSlice .) }}{{ $commits = slice . }}{{ end }}
-                            {{ range $commits }}
-                                {{ $short := substr . 0 7 }}
-                                {{ $refs = $refs | append (printf "commit [`%s`](%s/commit/%s)" $short $repo .) }}
-                            {{ end }}
-                        {{ end }}
-                        {{ $parenthetical := "" }}
-                        {{ if gt (len $refs) 0 }}
-                            {{ $parenthetical = printf " (%s)" (delimit $refs ", ") }}
-                        {{ end }}
-                        <div class="bug">
-                            {{ (printf "**Example: %s%s.**" .Title $parenthetical) | markdownify }}
-                            {{ .Content }}
-                        </div>
-                        {{ end }}
+    <div class="docs-layout">
+        {{ partial "docs-sidebar.html" (dict "current" "home" "intros" $intros) }}
+
+        <main class="docs-content">
+            <h1>Common Multi-Party Computation Pitfalls</h1>
+            <p class="lede">Welcome! This is a collection of common mistakes when implementing MPC protocols, to help developers and auditors implement MPC securely.</p>
+
+            <section id="about-the-project">
+                <h2>About the Project</h2>
+                <p>At the RWMPC 2025 workshop, a group of practitioners agreed that the field needed a shared, living reference for the implementation mistakes that keep recurring. We present a guide to common multi-party computation pitfalls, maintained by contributors from zkSecurity, Trail of Bits, Partisia, and Zama. The guide currently covers six categories: input validation, context binding, concurrency and state, insecure subprotocols, failure recovery, and adaptive inputs. It also catalogs improper use of the cryptographic primitives that MPC protocols rely on, since even a well-designed scheme can fail when its building blocks are misused. Each entry walks through a pitfall, how it can go wrong, and how to avoid it, with examples drawn from real, deployed libraries like tss-lib, WSTS, MP-SPDZ, and Drand.</p>
+            </section>
+
+            <section id="contributors">
+                <h2>Contributors</h2>
+                <ul class="contributors-list">
+                    {{ range .Site.Params.contributors }}
+                    <li>
+                        <span class="contributor-name">{{ .name }}</span>
+                        {{ with .handle }}<a class="contributor-handle" href="https://github.com/{{ . }}">@{{ . }}</a>{{ end }}
+                        {{ with .affiliation }}<span class="contributor-affiliation">{{ . }}</span>{{ end }}
+                    </li>
                     {{ end }}
-                </section>
-            {{ end }}
-        </section>
-    {{ end }}
-    </main>
+                </ul>
+            </section>
 
-    <footer>
-        {{ with .Site.Params.contributors }}
-        <div class="contributors">
-            {{ range . }}
-            <p>{{ .name }} (<a href="https://github.com/{{ .handle }}">@{{ .handle }}</a>, {{ .affiliation }})</p>
-            {{ end }}
-        </div>
-        {{ end }}
-        <a href="https://github.com/rot256/mpc-pitfalls">Discuss &amp; Contribute on GitHub</a>
-    </footer>
+            <section id="main-project-page">
+                <h2>Main Project Page</h2>
+                <p>The <a href="https://github.com/rot256/mpc-pitfalls">main project page</a> contains source files, contribution details, and project metadata.</p>
+            </section>
+
+            <section id="navigation">
+                <h2>Navigation</h2>
+                <ul class="docs-link-list">
+                    <li><a href="{{ "bugs/" | relURL }}">MPC Bug Tracker</a></li>
+                </ul>
+            </section>
+
+            <section id="links">
+                <h2>Links</h2>
+                <p>Audit your MPC implementation with the <a href="{{ "SKILL.md" | relURL }}">auditing skill</a>, or <a href="https://github.com/rot256/mpc-pitfalls">discuss and contribute on GitHub</a>.</p>
+            </section>
+
+            <section id="pitfall-categories">
+                <h2>Pitfall Categories</h2>
+                <ol class="docs-category-list">
+                    {{ range $intros }}
+                        <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+                    {{ end }}
+                </ol>
+            </section>
+        </main>
+    </div>
+
     <script defer src="{{ "scripts/theme.js" | relURL }}"></script>
     <script defer src="{{ "scripts/external-links.js" | relURL }}"></script>
 </body>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -41,11 +41,28 @@
 
         <main class="docs-content">
             <h1>Common Multi-Party Computation Pitfalls</h1>
-            <p class="lede">Welcome! This is an open, collaborative collection of common mistakes when implementing MPC protocols, built to help developers and auditors implement MPC securely.</p>
+            <p class="lede">Welcome! This is an open, collaborative collection of common mistakes when implementing MPC protocols.</p>
 
             <section id="about-the-project">
                 <h2>About the Project</h2>
-                <p>The project started at the RWMPC 2025 workshop, where practitioners from across the field agreed it needed a shared reference for the implementation mistakes that keep recurring. It is an open, collaborative initiative.</p>
+                <p>The project is built to help developers and auditors implement MPC securely. It started at the RWMPC 2025 workshop, where practitioners from across the field agreed it needed a shared reference for the implementation mistakes that keep recurring.</p>
+                <p>The <a href="{{ "bugs/" | relURL }}" target="_blank" rel="noopener">MPC Bug Tracker</a> backs the pitfalls with a searchable list of real-world bugs mapped to them.</p>
+            </section>
+
+            <section id="pitfall-categories-overview">
+                <h2>Current Pitfall Categories</h2>
+                <ul class="pitfall-list">
+                    {{ range $intros }}
+                    <li>
+                        <details class="category-details">
+                            <summary class="pitfall-list-item">
+                                <span>{{ .Title }}</span>
+                            </summary>
+                            <div class="category-details-content">{{ .Content }}</div>
+                        </details>
+                    </li>
+                    {{ end }}
+                </ul>
             </section>
 
             <section id="links">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -41,11 +41,16 @@
 
         <main class="docs-content">
             <h1>Common Multi-Party Computation Pitfalls</h1>
-            <p class="lede">Welcome! This is a collection of common mistakes when implementing MPC protocols, to help developers and auditors implement MPC securely.</p>
+            <p class="lede">Welcome! This is an open, collaborative collection of common mistakes when implementing MPC protocols, built to help developers and auditors implement MPC securely.</p>
 
             <section id="about-the-project">
                 <h2>About the Project</h2>
-                <p>At the RWMPC 2025 workshop, a group of practitioners agreed that the field needed a shared, living reference for the implementation mistakes that keep recurring. We present a guide to common multi-party computation pitfalls, maintained by contributors from zkSecurity, Trail of Bits, Partisia, and Zama. The guide currently covers six categories: input validation, context binding, concurrency and state, insecure subprotocols, failure recovery, and adaptive inputs. It also catalogs improper use of the cryptographic primitives that MPC protocols rely on, since even a well-designed scheme can fail when its building blocks are misused. Each entry walks through a pitfall, how it can go wrong, and how to avoid it, with examples drawn from real, deployed libraries like tss-lib, WSTS, MP-SPDZ, and Drand.</p>
+                <p>The project started at the RWMPC 2025 workshop, where practitioners from across the field agreed it needed a shared reference for the implementation mistakes that keep recurring. It is an open, collaborative initiative.</p>
+            </section>
+
+            <section id="links">
+                <h2>Links</h2>
+                <p>Audit your MPC implementation with the <a href="{{ "SKILL.md" | relURL }}">auditing skill</a>, or <a href="https://github.com/rot256/mpc-pitfalls">discuss and contribute on GitHub</a>.</p>
             </section>
 
             <section id="contributors">
@@ -59,32 +64,6 @@
                     </li>
                     {{ end }}
                 </ul>
-            </section>
-
-            <section id="main-project-page">
-                <h2>Main Project Page</h2>
-                <p>The <a href="https://github.com/rot256/mpc-pitfalls">main project page</a> contains source files, contribution details, and project metadata.</p>
-            </section>
-
-            <section id="navigation">
-                <h2>Navigation</h2>
-                <ul class="docs-link-list">
-                    <li><a href="{{ "bugs/" | relURL }}">MPC Bug Tracker</a></li>
-                </ul>
-            </section>
-
-            <section id="links">
-                <h2>Links</h2>
-                <p>Audit your MPC implementation with the <a href="{{ "SKILL.md" | relURL }}">auditing skill</a>, or <a href="https://github.com/rot256/mpc-pitfalls">discuss and contribute on GitHub</a>.</p>
-            </section>
-
-            <section id="pitfall-categories">
-                <h2>Pitfall Categories</h2>
-                <ol class="docs-category-list">
-                    {{ range $intros }}
-                        <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
-                    {{ end }}
-                </ol>
             </section>
         </main>
     </div>

--- a/layouts/partials/docs-sidebar.html
+++ b/layouts/partials/docs-sidebar.html
@@ -1,0 +1,21 @@
+{{ $current := default "" .current }}
+{{ $activeClass := default "" .activeClass }}
+<aside class="docs-sidebar">
+    <div class="docs-brand">Common MPC Pitfalls</div>
+
+    <nav aria-label="Site navigation">
+        <ul>
+            <li><a {{ if eq $current "home" }}aria-current="page"{{ end }} href="{{ "/" | relURL }}">Home</a></li>
+            <li><a {{ if eq $current "bugs" }}aria-current="page"{{ end }} href="{{ "bugs/" | relURL }}">MPC Bug Tracker</a></li>
+        </ul>
+    </nav>
+
+    <nav aria-label="Pitfall categories">
+        <h2>Pitfall Categories</h2>
+        <ul>
+            {{ range .intros }}
+                <li><a {{ if and $activeClass (eq .Params.class $activeClass) }}aria-current="page"{{ end }} href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+            {{ end }}
+        </ul>
+    </nav>
+</aside>

--- a/layouts/partials/page-controls.html
+++ b/layouts/partials/page-controls.html
@@ -1,0 +1,9 @@
+<button class="theme-toggle" type="button" data-theme-toggle aria-label="Switch theme"></button>
+
+<input class="sidebar-toggle" id="sidebar-toggle" type="checkbox" aria-label="Toggle navigation">
+<label class="sidebar-menu-button" for="sidebar-toggle" aria-label="Open navigation" title="Open navigation">
+    <span></span>
+    <span></span>
+    <span></span>
+</label>
+<label class="sidebar-backdrop" for="sidebar-toggle" aria-hidden="true"></label>

--- a/layouts/partials/pitfall-examples.html
+++ b/layouts/partials/pitfall-examples.html
@@ -1,0 +1,29 @@
+{{/*
+    Renders the real-world bug examples referenced by a pitfall's `display`
+    frontmatter. For each bug id it pulls the bug page, builds its reference
+    links via bug-refs.html, and renders the bug's full content. Mirrors the
+    "Example:" blocks produced by index.llms.txt.
+    Usage: {{ partial "pitfall-examples.html" . }} where . is the pitfall page.
+*/}}
+{{ with .Params.display }}
+    <div class="pitfall-examples">
+        {{ range . }}
+            {{ $bug := site.GetPage (printf "/bugs/%s" .) }}
+            {{ with $bug }}
+                {{ $refs := partial "bug-refs.html" . }}
+                <div class="pitfall-example">
+                    <h3 class="pitfall-example-title">
+                        <span class="pitfall-example-kicker">Example</span>
+                        <a href="{{ .RelPermalink }}">{{ .Title | markdownify | chomp | replaceRE "</?p>" "" | safeHTML }}</a>
+                        {{ if gt (len $refs) 0 }}
+                            <span class="pitfall-example-refs">({{ delimit $refs ", " | safeHTML }})</span>
+                        {{ end }}
+                    </h3>
+                    <div class="pitfall-example-body">
+                        {{ .Content }}
+                    </div>
+                </div>
+            {{ end }}
+        {{ end }}
+    </div>
+{{ end }}

--- a/layouts/partials/theme-head.html
+++ b/layouts/partials/theme-head.html
@@ -1,0 +1,21 @@
+<script>
+    (() => {
+        var KEY = "mpc-pitfalls-theme-mode";
+        var systemDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        var choice = null;
+        try {
+            // A manual theme choice persists while navigating between pages, but
+            // a full page refresh clears it so the theme falls back to the OS.
+            var nav = performance.getEntriesByType("navigation")[0];
+            var reloaded = nav ? nav.type === "reload"
+                : (performance.navigation && performance.navigation.type === 1);
+            if (reloaded) {
+                sessionStorage.removeItem(KEY);
+            } else {
+                choice = sessionStorage.getItem(KEY);
+            }
+        } catch (e) {}
+        document.documentElement.dataset.theme =
+            (choice === "dark" || choice === "light") ? choice : (systemDark ? "dark" : "light");
+    })();
+</script>

--- a/layouts/pitfalls/list.html
+++ b/layouts/pitfalls/list.html
@@ -6,11 +6,7 @@
     <title>Pitfall Categories</title>
     {{ $desc := "The current Common MPC Pitfalls categories." }}
     <meta name="description" content="{{ $desc }}">
-    <script>
-        (() => {
-            document.documentElement.dataset.theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-        })();
-    </script>
+    {{ partial "theme-head.html" . }}
     <link rel="icon" href="{{ "favicon.svg" | relURL }}" type="image/svg+xml">
     <link rel="icon" href="{{ "favicon.png" | relURL }}" type="image/png" sizes="1024x1024">
     <link rel="stylesheet" href="{{ "style.css" | relURL }}">

--- a/layouts/pitfalls/single.html
+++ b/layouts/pitfalls/single.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ .Title }} | Common MPC Pitfalls</title>
+    {{ $desc := cond .Params.intro (printf "%s pitfalls mapped to the Common MPC Pitfalls category." .Title) (printf "%s in the Common MPC Pitfalls collection." .Title) }}
+    <meta name="description" content="{{ $desc }}">
+    <script>
+        (() => {
+            document.documentElement.dataset.theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+        })();
+    </script>
+    <link rel="icon" href="{{ "favicon.svg" | relURL }}" type="image/svg+xml">
+    <link rel="icon" href="{{ "favicon.png" | relURL }}" type="image/png" sizes="1024x1024">
+    <link rel="stylesheet" href="{{ "style.css" | relURL }}">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.28/dist/katex.min.css">
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.28/dist/katex.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.28/dist/contrib/auto-render.min.js"
+        onload="renderMathInElement(document.body, {
+            delimiters: [
+                {left: '$$', right: '$$', display: true},
+                {left: '$', right: '$', display: false}
+            ]
+        });"></script>
+</head>
+<body class="docs-home-page">
+    {{ $allPages := where .Site.RegularPages "Section" "pitfalls" }}
+    {{ $intros := sort (where $allPages "Params.intro" true) "Params.order" }}
+    {{ $pitfalls := sort (where (where (where $allPages "Params.intro" "ne" true) "Params.hidden" "ne" true) "Params.class" .Params.class) "Params.order" }}
+
+    {{ partial "page-controls.html" . }}
+
+    <div class="docs-layout">
+        {{ partial "docs-sidebar.html" (dict "intros" $intros "activeClass" .Params.class) }}
+
+        <main class="docs-content category-page-content">
+            {{ if .Params.intro }}
+                <p class="eyebrow">Pitfall Category</p>
+                <h1>{{ .Title }}</h1>
+                <div class="category-intro">{{ .Content }}</div>
+
+                <section id="mapped-pitfalls">
+                    <h2>Mapped Pitfalls</h2>
+                    {{ if gt (len $pitfalls) 0 }}
+                        <ul class="pitfall-list">
+                            {{ range $pitfalls }}
+                                <li>
+                                    <button class="pitfall-list-item" type="button" data-pitfall-open="{{ .Title | anchorize }}" aria-haspopup="dialog">
+                                        <span>{{ .Title }}</span>
+                                    </button>
+                                </li>
+                            {{ end }}
+                        </ul>
+                    {{ else }}
+                        <p>No mapped pitfalls yet.</p>
+                    {{ end }}
+                </section>
+            {{ else }}
+                <p class="eyebrow">Pitfall</p>
+                <h1>{{ .Title }}</h1>
+                <article class="pitfall">
+                    {{ .Content }}
+                    {{ partial "pitfall-examples.html" . }}
+                </article>
+            {{ end }}
+        </main>
+    </div>
+
+    {{ if and .Params.intro (gt (len $pitfalls) 0) }}
+    <section class="pitfall-overlay" id="pitfall-overlay" aria-modal="true" role="dialog" aria-label="Pitfall detail" hidden>
+        <div class="pitfall-overlay-backdrop" data-pitfall-close></div>
+        <div class="pitfall-overlay-panel pitfall-overlay-panel--pitfall" role="document">
+            <div class="pitfall-overlay-toolbar">
+                <button class="pitfall-overlay-close" type="button" data-pitfall-close aria-label="Back to category" title="Back to category">←</button>
+            </div>
+            <p class="detail-eyebrow">Pitfall</p>
+            {{ range $pitfalls }}
+                <article class="pitfall pitfall-overlay-detail" id="{{ .Title | anchorize }}" data-pitfall-id="{{ .Title | anchorize }}" hidden>
+                    <h2 class="pitfall-overlay-title">{{ .Title }}</h2>
+                    {{ .Content }}
+                    {{ partial "pitfall-examples.html" . }}
+                </article>
+            {{ end }}
+            <button class="pitfall-overlay-top" type="button" data-pitfall-top aria-label="Scroll to top of pitfall" title="Back to top">↑</button>
+        </div>
+    </section>
+    {{ end }}
+
+    <script defer src="{{ "scripts/theme.js" | relURL }}"></script>
+    <script defer src="{{ "scripts/external-links.js" | relURL }}"></script>
+    <script defer src="{{ "scripts/pitfall-overlay.js" | relURL }}"></script>
+</body>
+</html>

--- a/layouts/pitfalls/single.html
+++ b/layouts/pitfalls/single.html
@@ -6,11 +6,7 @@
     <title>{{ .Title }} | Common MPC Pitfalls</title>
     {{ $desc := cond .Params.intro (printf "%s pitfalls mapped to the Common MPC Pitfalls category." .Title) (printf "%s in the Common MPC Pitfalls collection." .Title) }}
     <meta name="description" content="{{ $desc }}">
-    <script>
-        (() => {
-            document.documentElement.dataset.theme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-        })();
-    </script>
+    {{ partial "theme-head.html" . }}
     <link rel="icon" href="{{ "favicon.svg" | relURL }}" type="image/svg+xml">
     <link rel="icon" href="{{ "favicon.png" | relURL }}" type="image/png" sizes="1024x1024">
     <link rel="stylesheet" href="{{ "style.css" | relURL }}">

--- a/layouts/pitfalls/single.html
+++ b/layouts/pitfalls/single.html
@@ -40,8 +40,8 @@
                 <h1>{{ .Title }}</h1>
                 <div class="category-intro">{{ .Content }}</div>
 
-                <section id="mapped-pitfalls">
-                    <h2>Mapped Pitfalls</h2>
+                <section id="list-of-pitfalls">
+                    <h2>List of Pitfalls</h2>
                     {{ if gt (len $pitfalls) 0 }}
                         <ul class="pitfall-list">
                             {{ range $pitfalls }}
@@ -53,7 +53,7 @@
                             {{ end }}
                         </ul>
                     {{ else }}
-                        <p>No mapped pitfalls yet.</p>
+                        <p>No pitfalls yet.</p>
                     {{ end }}
                 </section>
             {{ else }}

--- a/static/scripts/bug-tracker.js
+++ b/static/scripts/bug-tracker.js
@@ -9,6 +9,7 @@
     const chart = document.querySelector("#category-chart");
     const legend = document.querySelector("#category-chart-legend");
     const bugOverlay = document.querySelector("#bug-overlay");
+    const bugPanel = bugOverlay.querySelector(".pitfall-overlay-panel");
     const bugPlaceholder = document.querySelector("#bug-overlay-placeholder");
     const details = [...document.querySelectorAll(".bug-detail")];
     const bugClose = [...document.querySelectorAll("[data-bug-close]")];
@@ -26,6 +27,27 @@
 
     const chartColors = ["#1a4a6e", "#c84d2f", "#678d58", "#8a5a99", "#b98322", "#3d7f91", "#9b4b5b"];
     const svgNS = "http://www.w3.org/2000/svg";
+
+    const scrollToElementTop = (element) => {
+        if (!element) return;
+
+        element.scrollTop = 0;
+        element.scrollTo?.(0, 0);
+        requestAnimationFrame(() => { element.scrollTop = 0; });
+    };
+
+    const scrollPageTop = () => {
+        const scrollingElement = document.scrollingElement || document.documentElement;
+        scrollingElement.scrollTop = 0;
+        document.documentElement.scrollTop = 0;
+        document.body.scrollTop = 0;
+        window.scrollTo?.(0, 0);
+        requestAnimationFrame(() => {
+            scrollingElement.scrollTop = 0;
+            document.documentElement.scrollTop = 0;
+            document.body.scrollTop = 0;
+        });
+    };
 
     const addOptions = (select, values, formatter = (value) => value) => {
         [...values].sort().forEach((value) => {
@@ -118,6 +140,7 @@
         bugPlaceholder.hidden = true;
         bugOverlay.hidden = false;
         document.body.classList.add("has-modal");
+        scrollToElementTop(bugPanel);
         bugOverlay.querySelector(".pitfall-overlay-close").focus();
     };
 
@@ -202,6 +225,18 @@
     });
 
     document.addEventListener("click", (event) => {
+        if (event.target.closest("[data-tracker-top]")) {
+            event.preventDefault();
+            scrollPageTop();
+            return;
+        }
+
+        if (event.target.closest("[data-bug-top]")) {
+            event.preventDefault();
+            scrollToElementTop(bugPanel);
+            return;
+        }
+
         const link = event.target.closest("[data-category-id]");
         if (!link || link.closest(".category-overlay-content")) return;
 

--- a/static/scripts/pitfall-overlay.js
+++ b/static/scripts/pitfall-overlay.js
@@ -1,0 +1,52 @@
+(() => {
+    const overlay = document.querySelector("#pitfall-overlay");
+    if (!overlay) return;
+
+    const panel = overlay.querySelector(".pitfall-overlay-panel");
+    const details = [...overlay.querySelectorAll(".pitfall-overlay-detail")];
+    const triggers = [...document.querySelectorAll("[data-pitfall-open]")];
+    const closers = [...overlay.querySelectorAll("[data-pitfall-close]")];
+    const toppers = [...overlay.querySelectorAll("[data-pitfall-top]")];
+    let lastTrigger = null;
+
+    const open = (id, trigger) => {
+        const active = details.find((detail) => detail.dataset.pitfallId === id);
+        if (!active) return;
+
+        details.forEach((detail) => { detail.hidden = detail !== active; });
+        lastTrigger = trigger || null;
+        overlay.hidden = false;
+        document.body.classList.add("has-modal");
+        panel.scrollTop = 0;
+        overlay.querySelector(".pitfall-overlay-close").focus();
+    };
+
+    const close = () => {
+        overlay.hidden = true;
+        document.body.classList.remove("has-modal");
+        details.forEach((detail) => { detail.hidden = true; });
+        if (lastTrigger) {
+            lastTrigger.focus();
+            lastTrigger = null;
+        }
+    };
+
+    triggers.forEach((trigger) => {
+        trigger.setAttribute("aria-controls", "pitfall-overlay");
+        trigger.addEventListener("click", () => open(trigger.dataset.pitfallOpen, trigger));
+    });
+
+    closers.forEach((element) => element.addEventListener("click", close));
+    toppers.forEach((element) => element.addEventListener("click", () => {
+        panel.scrollTo({ top: 0, behavior: "smooth" });
+    }));
+
+    document.addEventListener("keydown", (event) => {
+        if (event.key === "Escape" && !overlay.hidden) close();
+    });
+
+    // Deep-link: open the matching pitfall if the URL carries its anchor.
+    if (location.hash.length > 1) {
+        open(decodeURIComponent(location.hash.slice(1)), null);
+    }
+})();

--- a/static/scripts/theme.js
+++ b/static/scripts/theme.js
@@ -5,12 +5,10 @@
 
     const systemTheme = () => media.matches ? "dark" : "light";
 
-    const storedMode = () => {
-        const saved = localStorage.getItem(modeKey);
-        return saved === "dark" || saved === "light" ? saved : null;
-    };
-
-    const preferredTheme = () => storedMode() ?? systemTheme();
+    // Theme follows the OS. Drop any previously persisted manual choice so a
+    // reload always reflects the current OS preference (the toggle below only
+    // changes the theme for the current view, it is not saved).
+    try { localStorage.removeItem(modeKey); } catch (_) {}
 
     const sunIcon = '<svg viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>';
     const moonIcon = '<svg viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M20 14.5A8 8 0 0 1 9.5 4a7 7 0 1 0 10.5 10.5z"/></svg>';
@@ -27,21 +25,14 @@
     };
 
     document.addEventListener("DOMContentLoaded", () => {
-        applyTheme(preferredTheme());
+        applyTheme(systemTheme());
         document.querySelectorAll("[data-theme-toggle]").forEach((button) => {
             button.addEventListener("click", () => {
                 const next = root.dataset.theme === "dark" ? "light" : "dark";
-                if (next === systemTheme()) {
-                    localStorage.removeItem(modeKey);
-                } else {
-                    localStorage.setItem(modeKey, next);
-                }
                 applyTheme(next);
             });
         });
     });
 
-    media.addEventListener("change", () => {
-        if (!storedMode()) applyTheme(systemTheme());
-    });
+    media.addEventListener("change", () => applyTheme(systemTheme()));
 })();

--- a/static/scripts/theme.js
+++ b/static/scripts/theme.js
@@ -5,10 +5,15 @@
 
     const systemTheme = () => media.matches ? "dark" : "light";
 
-    // Theme follows the OS. Drop any previously persisted manual choice so a
-    // reload always reflects the current OS preference (the toggle below only
-    // changes the theme for the current view, it is not saved).
-    try { localStorage.removeItem(modeKey); } catch (_) {}
+    // A manual choice is remembered for the browsing session so it survives
+    // navigation between pages. The inline <head> script clears it on a full
+    // page refresh, so a reload falls back to the OS preference.
+    const storedChoice = () => {
+        try { return sessionStorage.getItem(modeKey); } catch (_) { return null; }
+    };
+    const saveChoice = (theme) => {
+        try { sessionStorage.setItem(modeKey, theme); } catch (_) {}
+    };
 
     const sunIcon = '<svg viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>';
     const moonIcon = '<svg viewBox="0 0 24 24" width="1em" height="1em" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M20 14.5A8 8 0 0 1 9.5 4a7 7 0 1 0 10.5 10.5z"/></svg>';
@@ -25,14 +30,21 @@
     };
 
     document.addEventListener("DOMContentLoaded", () => {
-        applyTheme(systemTheme());
+        // The inline <head> script already resolved the theme (a saved choice
+        // when navigating, the OS preference on a refresh). Mirror it into the
+        // toggle UI without overriding it.
+        applyTheme(root.dataset.theme || systemTheme());
         document.querySelectorAll("[data-theme-toggle]").forEach((button) => {
             button.addEventListener("click", () => {
                 const next = root.dataset.theme === "dark" ? "light" : "dark";
+                saveChoice(next);
                 applyTheme(next);
             });
         });
     });
 
-    media.addEventListener("change", () => applyTheme(systemTheme()));
+    // Follow live OS changes only while the user has not made a manual choice.
+    media.addEventListener("change", () => {
+        if (!storedChoice()) applyTheme(systemTheme());
+    });
 })();

--- a/static/style.css
+++ b/static/style.css
@@ -88,26 +88,6 @@ header p {
     color: var(--muted);
 }
 
-header p.skill-link {
-    margin-top: 1.2rem;
-    padding: 0.7rem 0.95rem;
-    font-size: 0.92rem;
-    color: var(--text);
-    background: var(--accent-soft);
-    border-left: 3px solid var(--accent);
-    border-radius: 0 4px 4px 0;
-}
-
-header p.tracker-link {
-    margin-top: 1rem;
-    font-size: 0.94rem;
-    font-weight: 600;
-}
-
-header p.skill-link a {
-    font-weight: 600;
-}
-
 header p.eyebrow {
     margin-bottom: 0.35rem;
     font-size: 0.78rem;
@@ -120,8 +100,388 @@ header p.eyebrow a {
     text-decoration: none;
 }
 
-.theme-toggle {
+.docs-home-page {
+    --text: #24313a;
+    --bg: #f7f9fb;
+    --surface: #ffffff;
+    --surface-soft: #eef4f8;
+    --accent: #1f6288;
+    --accent-dark: #154961;
+    --accent-soft: #dcebf4;
+    --border: #d8e1e7;
+    --muted: #5f6f7b;
+    --max-width: 1120px;
+}
+
+.docs-home-page[data-theme="dark"],
+[data-theme="dark"] .docs-home-page {
+    --text: #e7edf2;
+    --bg: #111517;
+    --surface: #171d21;
+    --surface-soft: #1b252b;
+    --accent: #8db8d8;
+    --accent-dark: #cce4f5;
+    --accent-soft: #1d2a32;
+    --border: #33424d;
+    --muted: #bac4cc;
+}
+
+.docs-layout {
+    display: grid;
+    grid-template-columns: 17rem minmax(0, 1fr);
+    min-height: 100vh;
+}
+
+.docs-sidebar {
+    position: sticky;
+    top: 0;
+    height: 100vh;
+    overflow-y: auto;
+    padding: 2rem 1.25rem;
+    background: var(--surface);
+    border-right: 1px solid var(--border);
+}
+
+.docs-brand {
+    display: block;
+    margin-bottom: 0.75rem;
+    color: var(--muted);
+    font-size: 1.2rem;
+    font-weight: 700;
+    line-height: 1.25;
+    text-decoration: none;
+}
+
+.docs-sidebar h2 {
+    margin: 0.55rem 0 0.3rem;
+    color: var(--muted);
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.docs-sidebar ul {
+    list-style: none;
+}
+
+.docs-sidebar nav {
+    max-width: none;
+    margin: 0;
+    padding: 0;
+}
+
+.docs-sidebar nav + nav {
+    margin-top: 0.7rem;
+}
+
+.docs-sidebar li + li {
+    margin-top: 0.28rem;
+}
+
+.docs-sidebar a {
+    display: block;
+    padding: 0.22rem 0;
+    text-decoration: none;
+}
+
+.docs-sidebar a[aria-current="page"] {
+    color: var(--text);
+    font-weight: 700;
+}
+
+.sidebar-toggle {
     position: fixed;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.sidebar-menu-button,
+.sidebar-backdrop {
+    display: none;
+}
+
+.tracker-page .theme-toggle {
+    position: absolute;
+    z-index: 40;
+}
+
+.tracker-page .sidebar-menu-button {
+    position: absolute;
+    top: 0.85rem;
+    left: 0.85rem;
+    z-index: 40;
+    display: inline-flex;
+    width: 2.25rem;
+    height: 2.25rem;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 0.22rem;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text);
+    background: var(--surface);
+    box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.12);
+    cursor: pointer;
+}
+
+.tracker-page .sidebar-menu-button span {
+    display: block;
+    width: 1.15rem;
+    height: 2px;
+    border-radius: 999px;
+    background: currentColor;
+}
+
+.tracker-page .docs-layout {
+    grid-template-columns: 1fr;
+}
+
+.tracker-page .docs-sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 35;
+    width: min(17rem, 85vw);
+    height: 100vh;
+    padding: 3.8rem 1.25rem 2rem;
+    border-right: 1px solid var(--border);
+    border-bottom: 0;
+    box-shadow: var(--shadow);
+    transform: translateX(-100%);
+    transition: transform 0.18s ease;
+}
+
+.tracker-page .sidebar-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 30;
+    background: var(--overlay-bg);
+}
+
+.tracker-page .sidebar-toggle:checked ~ .sidebar-backdrop {
+    display: block;
+}
+
+.tracker-page .sidebar-toggle:checked ~ .docs-layout .docs-sidebar {
+    transform: translateX(0);
+}
+
+.docs-content {
+    width: min(46rem, calc(100vw - 21rem));
+    margin: 0 auto;
+    padding: 3.2rem 0 4rem;
+}
+
+.docs-content .eyebrow {
+    margin-bottom: 0.35rem;
+    color: var(--muted);
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.docs-content h1 {
+    color: var(--accent);
+    font-size: clamp(2rem, 5vw, 3.2rem);
+    line-height: 1.12;
+    margin-bottom: 0.8rem;
+}
+
+.docs-content .lede {
+    max-width: 40rem;
+    color: var(--muted);
+    font-size: 1.08rem;
+}
+
+.docs-content section {
+    margin-top: 2.2rem;
+    padding-top: 0;
+}
+
+.docs-content h2 {
+    color: var(--accent);
+    font-size: 1.35rem;
+    line-height: 1.25;
+    margin-bottom: 0.45rem;
+}
+
+.docs-link-list {
+    margin-top: 0.5rem;
+    list-style: disc;
+    padding-left: 1.2rem;
+}
+
+.docs-link-list li {
+    padding: 0.35rem 0;
+}
+
+.contributors-list {
+    margin-top: 0.5rem;
+    list-style: disc;
+    padding-left: 1.2rem;
+}
+
+.contributors-list li {
+    padding: 0.35rem 0;
+}
+
+.contributor-name {
+    font-weight: 600;
+}
+
+.contributor-affiliation {
+    color: var(--subtle);
+    font-size: 0.9rem;
+}
+
+
+.docs-category-list {
+    counter-reset: category;
+    margin-top: 0.7rem;
+    list-style: none;
+}
+
+.docs-category-list li {
+    counter-increment: category;
+    display: grid;
+    grid-template-columns: 1.8rem minmax(0, 1fr);
+    gap: 0.45rem;
+    break-inside: avoid;
+    margin-bottom: 0.45rem;
+}
+
+.docs-category-list li::before {
+    content: counter(category) ".";
+    color: var(--muted);
+}
+
+.category-intro {
+    margin-top: 1rem;
+}
+
+/* Clickable list of pitfalls that open in the overlay (overlay variant). */
+.pitfall-list {
+    margin-top: 0.9rem;
+    padding: 0;
+    list-style: none;
+}
+
+.pitfall-list li {
+    border-top: 1px solid var(--border);
+}
+
+.pitfall-list li:last-child {
+    border-bottom: 1px solid var(--border);
+}
+
+.pitfall-list-item {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 0.7rem;
+    gap: 0.55rem;
+    align-items: center;
+    width: 100%;
+    padding: 0.8rem 0;
+    border: 0;
+    background: transparent;
+    color: var(--accent);
+    font: inherit;
+    font-weight: 700;
+    text-align: left;
+    cursor: pointer;
+}
+
+.pitfall-list-item::after {
+    content: "";
+    justify-self: end;
+    width: 0;
+    height: 0;
+    border-top: 0.28rem solid transparent;
+    border-bottom: 0.28rem solid transparent;
+    border-left: 0.42rem solid currentColor;
+}
+
+.pitfall-list-item:hover {
+    color: var(--accent-dark);
+}
+
+.pitfall-overlay-title {
+    margin: 0 0 0.9rem;
+    color: var(--accent);
+    font-size: 1.4rem;
+    line-height: 1.3;
+}
+
+/* Real-world bug examples shown beneath a pitfall's explanation. */
+.pitfall-examples {
+    margin-top: 1.5rem;
+}
+
+.pitfall-example {
+    margin-bottom: 1rem;
+    padding: 0.9rem 1.1rem;
+    background: var(--surface-soft);
+    border-left: 3px solid var(--accent);
+    border-radius: 0 5px 5px 0;
+}
+
+.pitfall-example:last-child {
+    margin-bottom: 0;
+}
+
+.pitfall-example-title {
+    margin: 0 0 0.6rem;
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1.4;
+}
+
+.pitfall-example-kicker {
+    display: inline-block;
+    margin-right: 0.5em;
+    padding: 1px 7px;
+    font-size: 0.66rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--surface);
+    background: var(--accent);
+    border-radius: 3px;
+    vertical-align: 0.12em;
+}
+
+.pitfall-example-title a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+.pitfall-example-title a:hover {
+    text-decoration: underline;
+}
+
+.pitfall-example-refs {
+    font-size: 0.82rem;
+    font-weight: normal;
+    color: var(--subtle);
+}
+
+.pitfall-example-refs a {
+    color: var(--muted);
+}
+
+.pitfall-example-body > :first-child {
+    margin-top: 0;
+}
+
+.pitfall-example-body > :last-child {
+    margin-bottom: 0;
+}
+
+.theme-toggle {
+    position: absolute;
     top: 0.85rem;
     right: 0.85rem;
     z-index: 10;
@@ -403,54 +763,6 @@ main {
     background-color: #22313a;
 }
 
-.category {
-    margin-top: 3rem;
-}
-
-.category-heading {
-    font-size: 1.5rem;
-    color: var(--accent);
-    border-bottom: 2px solid var(--accent);
-    padding-bottom: 0.4rem;
-    margin-bottom: 0.5rem;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-}
-
-.category > .pitfall:first-of-type {
-    margin-top: 1rem;
-    padding-top: 0;
-    border-top: none;
-}
-
-nav .toc {
-    list-style: none;
-    padding-left: 0;
-}
-
-nav .toc-category {
-    margin-bottom: 1rem;
-}
-
-nav .toc-category-link {
-    display: block;
-    font-weight: 600;
-    color: var(--accent);
-    text-decoration: none;
-    margin-bottom: 0.25rem;
-    text-transform: uppercase;
-    font-size: 0.88rem;
-    letter-spacing: 0.03em;
-}
-
-nav .toc-category-link:hover {
-    text-decoration: underline;
-}
-
-nav .toc-category > ol {
-    padding-left: 1.5rem;
-}
-
 footer {
     max-width: var(--max-width);
     margin: 0 auto;
@@ -466,7 +778,9 @@ footer a {
 }
 
 .page-back-arrow,
-.pitfall-overlay-close {
+.pitfall-overlay-close,
+.pitfall-overlay-top,
+.tracker-page-top {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -493,14 +807,18 @@ footer a {
 }
 
 .page-back-arrow:hover,
-.pitfall-overlay-close:hover {
+.pitfall-overlay-close:hover,
+.pitfall-overlay-top:hover,
+.tracker-page-top:hover {
     color: var(--accent);
     background: var(--accent-soft);
     opacity: 1;
 }
 
 .page-back-arrow:focus-visible,
-.pitfall-overlay-close:focus-visible {
+.pitfall-overlay-close:focus-visible,
+.pitfall-overlay-top:focus-visible,
+.tracker-page-top:focus-visible {
     outline: 1px solid var(--accent);
     outline-offset: 2px;
     background: transparent;
@@ -523,8 +841,16 @@ strong {
     --max-width: 1120px;
 }
 
-.tracker-page main {
-    padding-top: 1.5rem;
+.tracker-page .tracker-content {
+    width: min(70rem, calc(100vw - 3rem));
+    max-width: none;
+    padding: 3.2rem 0 4rem;
+}
+
+.tracker-page .tracker-header {
+    max-width: none;
+    margin: 0 0 1.5rem;
+    padding: 0 0 1.75rem;
 }
 
 .tracker-summary {
@@ -874,15 +1200,21 @@ strong {
     font-style: italic;
 }
 
-.bug-detail-panel {
-    position: sticky;
-    top: 1rem;
-    max-height: calc(100vh - 2rem);
-    overflow-y: auto;
-    padding: 1rem;
-    border-top: 2px solid var(--accent);
-    border-bottom: 1px solid var(--border);
+.tracker-page-top {
+    position: fixed;
+    right: 1rem;
+    bottom: 1rem;
+    z-index: 10;
+    color: var(--accent);
     background: var(--surface);
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow);
+    opacity: 0.95;
+    font-size: 1.15rem;
+}
+
+.tracker-page-top[hidden] {
+    display: none;
 }
 
 .detail-eyebrow {
@@ -982,7 +1314,7 @@ strong {
 .pitfall-overlay {
     position: fixed;
     inset: 0;
-    z-index: 20;
+    z-index: 60;
     display: grid;
     place-items: center;
     padding: 1.5rem;
@@ -1025,6 +1357,55 @@ strong {
     cursor: pointer;
 }
 
+/* Pitfall overlay: a sticky toolbar keeps the back and scroll-to-top buttons
+   in view while the (often long) pitfall content scrolls underneath. */
+.pitfall-overlay-panel--pitfall {
+    padding-top: 0;
+}
+
+.pitfall-overlay-toolbar {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin: 0 -1.5rem 0.6rem;
+    padding: 0.7rem 0.85rem;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+}
+
+.pitfall-overlay-toolbar .pitfall-overlay-close {
+    position: static;
+}
+
+.pitfall-overlay-panel--pitfall > .detail-eyebrow {
+    margin-left: 0;
+}
+
+/* Scroll-to-top button: floats over the pitfall content, sticky to the bottom
+   of the panel (not the viewport) and centered. */
+.pitfall-overlay-top {
+    position: sticky;
+    bottom: 1rem;
+    z-index: 5;
+    display: flex;
+    margin: 0.5rem auto 0.25rem;
+    width: 2.5rem;
+    height: 2.5rem;
+    color: var(--accent);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow);
+    opacity: 0.95;
+    font-size: 1.15rem;
+}
+
+.pitfall-overlay-top:hover {
+    opacity: 1;
+}
+
 .category-overlay-content h2 {
     margin-left: 2.4rem;
     margin-bottom: 0.75rem;
@@ -1044,6 +1425,94 @@ strong {
 }
 
 @media (max-width: 900px) {
+    .sidebar-menu-button {
+        position: absolute;
+        top: 0.85rem;
+        left: 0.85rem;
+        z-index: 40;
+        display: inline-flex;
+        width: 2.25rem;
+        height: 2.25rem;
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+        gap: 0.22rem;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        color: var(--text);
+        background: var(--surface);
+        box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.12);
+        cursor: pointer;
+    }
+
+    .sidebar-menu-button span {
+        display: block;
+        width: 1.15rem;
+        height: 2px;
+        border-radius: 999px;
+        background: currentColor;
+    }
+
+    .sidebar-backdrop {
+        position: fixed;
+        inset: 0;
+        z-index: 30;
+        background: var(--overlay-bg);
+    }
+
+    .sidebar-toggle:checked ~ .sidebar-backdrop {
+        display: block;
+    }
+
+    .docs-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .docs-sidebar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        z-index: 35;
+        width: min(17rem, 85vw);
+        height: 100vh;
+        padding: 3.8rem 1.25rem 2rem;
+        border-right: 1px solid var(--border);
+        border-bottom: 0;
+        box-shadow: var(--shadow);
+        transform: translateX(-100%);
+        transition: transform 0.18s ease;
+    }
+
+    .sidebar-toggle:checked ~ .docs-layout .docs-sidebar {
+        transform: translateX(0);
+    }
+
+    .docs-sidebar ul {
+        display: block;
+    }
+
+    .docs-sidebar li + li {
+        margin-top: 0.28rem;
+    }
+
+    .docs-sidebar h2 {
+        margin-top: 0.55rem;
+    }
+
+    .docs-content {
+        width: auto;
+        padding: 4.25rem 1rem 3rem;
+    }
+
+    .tracker-page .tracker-content {
+        width: auto;
+        padding: 4.25rem 1rem 3rem;
+    }
+
+    .docs-category-list {
+        columns: 1;
+    }
+
     .category-chart-card,
     .tracker-controls,
     .tracker-workspace {
@@ -1052,11 +1521,6 @@ strong {
 
     .tracker-table {
         min-width: 820px;
-    }
-
-    .bug-detail-panel {
-        position: static;
-        max-height: none;
     }
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -363,6 +363,37 @@ header p.eyebrow a {
     margin-top: 1rem;
 }
 
+/* Home-page category list: each row unravels its description in place. */
+.category-details > summary {
+    list-style: none;
+}
+
+.category-details > summary::-webkit-details-marker {
+    display: none;
+}
+
+.category-details > summary::after {
+    transition: transform 0.15s ease;
+}
+
+.category-details[open] > summary::after {
+    transform: rotate(90deg);
+}
+
+.category-details-content {
+    padding: 0 0 0.9rem;
+    color: var(--text);
+    line-height: 1.55;
+}
+
+.category-details-content p {
+    margin: 0;
+}
+
+.category-details-content p + p {
+    margin-top: 0.6rem;
+}
+
 /* Clickable list of pitfalls that open in the overlay (overlay variant). */
 .pitfall-list {
     margin-top: 0.9rem;


### PR DESCRIPTION
## Summary

A full visual and structural refont of the site (layouts, scripts, styles, config). No content files (`content/`) are touched, so this rebases cleanly on top of the recent content merge.

### Highlights
- **Home page**: expanded *About the Project* (purpose + audience), a concise MPC Bug Tracker mention, and a new *Current Pitfall Categories* section where each row unravels its description in place via native `<details>`.
- **Pitfall categories**: category pages now show a *List of Pitfalls* (renamed from "Mapped Pitfalls") with an overlay detail view (`pitfall-overlay.js`).
- **Bug tracker**: refreshed list/detail layouts plus supporting `bug-tracker.js`.
- **Theming & controls**: reworked `theme.js` and shared page controls partial.
- **Styles**: substantial `style.css` overhaul (tokens, layout, components).

🤖 Generated with [Claude Code](https://claude.com/claude-code)